### PR TITLE
added options to be able to set the scrollContainer and an offsetTopOverride value

### DIFF
--- a/lrStickyHeader.js
+++ b/lrStickyHeader.js
@@ -44,42 +44,54 @@
       }
     },
     eventListener: function eventListener () {
-      var offsetTop = getOffset(this.thead, 'offsetTop');
+      var offsetTop = this.offsetTopOverride ? this.offsetTopOverride : getOffset(this.thead, 'offsetTop');
       var offsetLeft = getOffset(this.thead, 'offsetLeft');
       var classes = this.thead.className.split(' ');
 
-      if (this.stick !== true && (offsetTop - window.scrollY < 0)) {
-        this.stick = true;
-        this.treshold = offsetTop;
-        this.setWidth();
-        this.thead.style.left = offsetLeft + 'px';
-        this.thead.style.top = 0;
-        setTimeout(function () {
-          classes.push('lr-sticky-header');
-          this.thead.style.position = 'fixed';
-          this.thead.className = classes.join(' ');
-        }.bind(this), 0);
+      if (this.stick !== true) {
+        var scrollPosition = this.isWindowScroll ? this.scrollContainer.scrollY : this.scrollContainer.scrollTop;
+        if (offsetTop - scrollPosition < 0) {
+          this.stick = true;
+          this.treshold = offsetTop;
+          this.setWidth();
+          this.thead.style.left = offsetLeft + 'px';
+          this.thead.style.top = this.isWindowScroll ? 0 : this.scrollContainer.getBoundingClientRect().top + 'px';
+          setTimeout(function () {
+            classes.push('lr-sticky-header');
+            this.thead.style.position = 'fixed';
+            this.thead.className = classes.join(' ');
+          }.bind(this), 0);
+        }
       }
 
-      if (this.stick === true && (this.treshold - window.scrollY > 0)) {
-        this.stick = false;
-        this.thead.style.position = 'initial';
-        classes.splice(classes.indexOf('lr-sticky-header'), 1);
-        this.thead.className = (classes).join(' ');
+      if (this.stick === true) {
+        var scrollPosition = this.isWindowScroll ? this.scrollContainer.scrollY : this.scrollContainer.scrollTop;
+        if (this.treshold - scrollPosition > 0) {
+          this.stick = false;
+          this.thead.style.position = 'initial';
+          classes.splice(classes.indexOf('lr-sticky-header'), 1);
+          this.thead.className = (classes).join(' ');
+        }
       }
     }
   };
 
-  return function lrStickyHeader (tableElement) {
+  return function lrStickyHeader (tableElement, options) {
+    options                   = options || {};
+    options.scrollContainer   = options.scrollContainer || window;
+    options.offsetTopOverride = options.offsetTopOverride || null;
+
+    var isWindowScroll = options.scrollContainer === window;
+
     var thead;
     var tbody;
 
     if (tableElement.tagName !== 'TABLE') {
       throw new Error('lrStickyHeader only works on table element');
     }
+
     tbody = tableElement.getElementsByTagName('TBODY');
     thead = tableElement.getElementsByTagName('THEAD');
-
     if (!thead.length) {
       throw new Error('could not find the thead group element');
     }
@@ -91,9 +103,11 @@
     thead = thead[0];
     tbody = tbody[0];
 
-
     var stickyTable = Object.create(sticky, {
       element: {value: tableElement},
+      scrollContainer: { value: options.scrollContainer },
+      isWindowScroll: { value: isWindowScroll },
+      offsetTopOverride: { value: options.offsetTopOverride },
       thead: {
         get: function () {
           return thead;
@@ -107,12 +121,11 @@
     });
 
     var listener = stickyTable.eventListener.bind(stickyTable);
-    window.addEventListener('scroll', listener);
+    options.scrollContainer.addEventListener('scroll', listener);
     stickyTable.clean = function clean () {
-      window.removeEventListener('scroll', listener);
+      options.scrollContainer.removeEventListener('scroll', listener);
     };
 
     return stickyTable;
   };
 });
-

--- a/lrStickyHeader.js
+++ b/lrStickyHeader.js
@@ -44,12 +44,12 @@
       }
     },
     eventListener: function eventListener () {
-      var offsetTop = this.offsetTopOverride ? this.offsetTopOverride : getOffset(this.thead, 'offsetTop');
-      var offsetLeft = getOffset(this.thead, 'offsetLeft');
-      var classes = this.thead.className.split(' ');
+      var offsetTop      = this.offsetTopOverride ? this.offsetTopOverride : getOffset(this.thead, 'offsetTop');
+      var offsetLeft     = getOffset(this.thead, 'offsetLeft');
+      var classes        = this.thead.className.split(' ');
+      var scrollPosition = this.isWindowScroll ? this.scrollContainer.scrollY : this.scrollContainer.scrollTop;
 
-      if (this.stick !== true) {
-        var scrollPosition = this.isWindowScroll ? this.scrollContainer.scrollY : this.scrollContainer.scrollTop;
+      if (this.stick !== true && (offsetTop - scrollPosition < 0)) {
         if (offsetTop - scrollPosition < 0) {
           this.stick = true;
           this.treshold = offsetTop;
@@ -64,8 +64,7 @@
         }
       }
 
-      if (this.stick === true) {
-        var scrollPosition = this.isWindowScroll ? this.scrollContainer.scrollY : this.scrollContainer.scrollTop;
+      if (this.stick === true && (this.treshold - scrollPosition > 0)) {
         if (this.treshold - scrollPosition > 0) {
           this.stick = false;
           this.thead.style.position = 'initial';

--- a/lrStickyHeader.js
+++ b/lrStickyHeader.js
@@ -50,27 +50,23 @@
       var scrollPosition = this.isWindowScroll ? this.scrollContainer.scrollY : this.scrollContainer.scrollTop;
 
       if (this.stick !== true && (offsetTop - scrollPosition < 0)) {
-        if (offsetTop - scrollPosition < 0) {
-          this.stick = true;
-          this.treshold = offsetTop;
-          this.setWidth();
-          this.thead.style.left = offsetLeft + 'px';
-          this.thead.style.top = this.isWindowScroll ? 0 : this.scrollContainer.getBoundingClientRect().top + 'px';
-          setTimeout(function () {
-            classes.push('lr-sticky-header');
-            this.thead.style.position = 'fixed';
-            this.thead.className = classes.join(' ');
-          }.bind(this), 0);
-        }
+        this.stick = true;
+        this.treshold = offsetTop;
+        this.setWidth();
+        this.thead.style.left = offsetLeft + 'px';
+        this.thead.style.top = this.isWindowScroll ? 0 : this.scrollContainer.getBoundingClientRect().top + 'px';
+        setTimeout(function () {
+          classes.push('lr-sticky-header');
+          this.thead.style.position = 'fixed';
+          this.thead.className = classes.join(' ');
+        }.bind(this), 0);
       }
 
       if (this.stick === true && (this.treshold - scrollPosition > 0)) {
-        if (this.treshold - scrollPosition > 0) {
-          this.stick = false;
-          this.thead.style.position = 'initial';
-          classes.splice(classes.indexOf('lr-sticky-header'), 1);
-          this.thead.className = (classes).join(' ');
-        }
+        this.stick = false;
+        this.thead.style.position = 'initial';
+        classes.splice(classes.indexOf('lr-sticky-header'), 1);
+        this.thead.className = (classes).join(' ');
       }
     }
   };


### PR DESCRIPTION
I needed to be able to have the sticky `thead` functionality inside an absolutely scrolling div container. Originally the scroll listeners were set to the `window` and the `top` position was always set to 0.

I've added an `options` object with the following properties available:
- `scrollContainer` - default `window`. A HTML element that should be used when calculating scroll top offsets for the positioning of the fixed `thead` element.
- `offsetTopOverride` - default unused. An integer value overriding the `offsetTop` which is used to calculate when the `thead` should start being fixed when scrolling. Sometimes you may want to start the fixed scrolling immediately or after a set number of pixes. For example the table I was using it with had an extra row under the header with search filter information.
