### PR TITLE
Enable sticky header in fixed height parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ None
 var tableElement = document.getElementById('table');
 
 var stickyTable = lrStickyHeader(tableElement);
+
+var parentElement = document.getElementById('scrollPanel');
+var stickyTable2 = lrStickyHeader(tableElement, {parent: parentElement});
 ```
 
 ### style

--- a/example.html
+++ b/example.html
@@ -12,6 +12,11 @@
     background: lightblue;
     transition: all 0.6s;
   }
+
+  #scrollPanel {
+    height: 500px;
+    overflow-y: auto;
+  }
 </style>
 <h1 class="text-center">Stick me !</h1>
 
@@ -4462,11 +4467,2240 @@
     </div>
   </div>
 </div>
+
+<div class="container">
+  <div class="row">
+    <div class="col-md-12">
+      <h2 class="text-center">stick me please !!!!</h2>
+  <div id="scrollPanel">
+      <table class="table table-bordered">
+        <thead>
+        <tr>
+          <th class="headerSort headerSortDown" tabindex="0" role="columnheader button" title="Sort descending">Code
+          </th>
+          <th class="headerSort" tabindex="0" role="columnheader button" title="Sort ascending">Country name</th>
+          <th class="headerSort" tabindex="0" role="columnheader button" title="Sort ascending">Year</th>
+          <th class="headerSort" tabindex="0" role="columnheader button" title="Sort ascending">ccTLD</th>
+          <th width="120" class="headerSort" tabindex="0" role="columnheader button" title="Sort ascending"><span class="nowrap">ISO 3166-2</span>
+          </th>
+          <th class="" title="">Notes</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AD</span></td>
+          <td><a href="/wiki/Andorra" title="Andorra">Andorra</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ad" title=".ad">.ad</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AD" title="ISO 3166-2:AD">ISO 3166-2:AD</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AE</span></td>
+          <td><a href="/wiki/United_Arab_Emirates" title="United Arab Emirates">United Arab Emirates</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ae" title=".ae">.ae</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AE" title="ISO 3166-2:AE">ISO 3166-2:AE</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AF</span></td>
+          <td><a href="/wiki/Afghanistan" title="Afghanistan">Afghanistan</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.af" title=".af">.af</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AF" title="ISO 3166-2:AF">ISO 3166-2:AF</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AG</span></td>
+          <td><a href="/wiki/Antigua_and_Barbuda" title="Antigua and Barbuda">Antigua and Barbuda</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ag" title=".ag">.ag</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AG" title="ISO 3166-2:AG">ISO 3166-2:AG</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AI</span></td>
+          <td><a href="/wiki/Anguilla" title="Anguilla">Anguilla</a></td>
+          <td>1983</td>
+          <td><a href="/wiki/.ai" title=".ai">.ai</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AI" title="ISO 3166-2:AI">ISO 3166-2:AI</a></span></td>
+          <td><span style="font-family: monospace, monospace;">AI</span> previously represented <a
+            href="/wiki/French_Territory_of_the_Afars_and_the_Issas"
+            title="French Territory of the Afars and the Issas">French
+            Afar and Issas</a></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AL</span></td>
+          <td><a href="/wiki/Albania" title="Albania">Albania</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.al" title=".al">.al</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AL" title="ISO 3166-2:AL">ISO 3166-2:AL</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AM</span></td>
+          <td><a href="/wiki/Armenia" title="Armenia">Armenia</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.am" title=".am">.am</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AM" title="ISO 3166-2:AM">ISO 3166-2:AM</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AO</span></td>
+          <td><a href="/wiki/Angola" title="Angola">Angola</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ao" title=".ao">.ao</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AO" title="ISO 3166-2:AO">ISO 3166-2:AO</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AQ</span></td>
+          <td><a href="/wiki/Antarctica" title="Antarctica">Antarctica</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.aq" title=".aq">.aq</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AQ" title="ISO 3166-2:AQ">ISO 3166-2:AQ</a></span></td>
+          <td>Covers the territories south of <a href="/wiki/60th_parallel_south" title="60th parallel south">60° south
+            latitude</a><br>
+            Code taken from name in <a href="/wiki/French_language" title="French language">French</a>: <i><span
+              lang="fr"
+              xml:lang="fr">Antarctique</span></i>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AR</span></td>
+          <td><a href="/wiki/Argentina" title="Argentina">Argentina</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ar" title=".ar">.ar</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AR" title="ISO 3166-2:AR">ISO 3166-2:AR</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AS</span></td>
+          <td><a href="/wiki/American_Samoa" title="American Samoa">American Samoa</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.as" title=".as">.as</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AS" title="ISO 3166-2:AS">ISO 3166-2:AS</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AT</span></td>
+          <td><a href="/wiki/Austria" title="Austria">Austria</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.at" title=".at">.at</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AT" title="ISO 3166-2:AT">ISO 3166-2:AT</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AU</span></td>
+          <td><a href="/wiki/Australia" title="Australia">Australia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.au" title=".au">.au</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AU" title="ISO 3166-2:AU">ISO 3166-2:AU</a></span></td>
+          <td>Includes the <a href="/wiki/Ashmore_and_Cartier_Islands" title="Ashmore and Cartier Islands">Ashmore and
+            Cartier
+            Islands</a> and the <a href="/wiki/Coral_Sea_Islands" title="Coral Sea Islands">Coral Sea Islands</a></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AW</span></td>
+          <td><a href="/wiki/Aruba" title="Aruba">Aruba</a></td>
+          <td>1986</td>
+          <td><a href="/wiki/.aw" title=".aw">.aw</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AW" title="ISO 3166-2:AW">ISO 3166-2:AW</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AX</span></td>
+          <td><span style="display:none;" class="sortkey">Aland Islands !</span><span class="sorttext"><a
+            href="/wiki/%C3%85land_Islands" title="Åland Islands">Åland Islands</a></span></td>
+          <td>2004</td>
+          <td><a href="/wiki/.ax" title=".ax">.ax</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AX" title="ISO 3166-2:AX">ISO 3166-2:AX</a></span></td>
+          <td>An autonomous province of <a href="/wiki/Finland" title="Finland">Finland</a></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">AZ</span></td>
+          <td><a href="/wiki/Azerbaijan" title="Azerbaijan">Azerbaijan</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.az" title=".az">.az</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:AZ" title="ISO 3166-2:AZ">ISO 3166-2:AZ</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BA</span></td>
+          <td><a href="/wiki/Bosnia_and_Herzegovina" title="Bosnia and Herzegovina">Bosnia and Herzegovina</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.ba" title=".ba">.ba</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BA" title="ISO 3166-2:BA">ISO 3166-2:BA</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BB</span></td>
+          <td><a href="/wiki/Barbados" title="Barbados">Barbados</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.bb" title=".bb">.bb</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BB" title="ISO 3166-2:BB">ISO 3166-2:BB</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BD</span></td>
+          <td><a href="/wiki/Bangladesh" title="Bangladesh">Bangladesh</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.bd" title=".bd">.bd</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BD" title="ISO 3166-2:BD">ISO 3166-2:BD</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BE</span></td>
+          <td><a href="/wiki/Belgium" title="Belgium">Belgium</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.be" title=".be">.be</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BE" title="ISO 3166-2:BE">ISO 3166-2:BE</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BF</span></td>
+          <td><a href="/wiki/Burkina_Faso" title="Burkina Faso">Burkina Faso</a></td>
+          <td>1984</td>
+          <td><a href="/wiki/.bf" title=".bf">.bf</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BF" title="ISO 3166-2:BF">ISO 3166-2:BF</a></span></td>
+          <td>Name changed from <i><a href="/wiki/Republic_of_Upper_Volta" title="Republic of Upper Volta">Upper
+            Volta</a></i>
+            (<span style="font-family: monospace, monospace;">HV</span>)
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BG</span></td>
+          <td><a href="/wiki/Bulgaria" title="Bulgaria">Bulgaria</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.bg" title=".bg">.bg</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BG" title="ISO 3166-2:BG">ISO 3166-2:BG</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BH</span></td>
+          <td><a href="/wiki/Bahrain" title="Bahrain">Bahrain</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.bh" title=".bh">.bh</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BH" title="ISO 3166-2:BH">ISO 3166-2:BH</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BI</span></td>
+          <td><a href="/wiki/Burundi" title="Burundi">Burundi</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.bi" title=".bi">.bi</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BI" title="ISO 3166-2:BI">ISO 3166-2:BI</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BJ</span></td>
+          <td><a href="/wiki/Benin" title="Benin">Benin</a></td>
+          <td>1977</td>
+          <td><a href="/wiki/.bj" title=".bj">.bj</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BJ" title="ISO 3166-2:BJ">ISO 3166-2:BJ</a></span></td>
+          <td>Name changed from <i><a href="/wiki/Republic_of_Dahomey" title="Republic of Dahomey">Dahomey</a></i>
+            (<span
+              style="font-family: monospace, monospace;">DY</span>)
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BL</span></td>
+          <td><a href="/wiki/Saint_Barth%C3%A9lemy" title="Saint Barthélemy">Saint Barthélemy</a></td>
+          <td>2007</td>
+          <td><a href="/wiki/.bl" title=".bl">.bl</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BL" title="ISO 3166-2:BL">ISO 3166-2:BL</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BM</span></td>
+          <td><a href="/wiki/Bermuda" title="Bermuda">Bermuda</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.bm" title=".bm">.bm</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BM" title="ISO 3166-2:BM">ISO 3166-2:BM</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BN</span></td>
+          <td><a href="/wiki/Brunei" title="Brunei">Brunei Darussalam</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.bn" title=".bn">.bn</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BN" title="ISO 3166-2:BN">ISO 3166-2:BN</a></span></td>
+          <td>ISO country name follows UN designation (common name: <i>Brunei</i>)</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BO</span></td>
+          <td><a href="/wiki/Bolivia" title="Bolivia">Bolivia, Plurinational State of</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.bo" title=".bo">.bo</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BO" title="ISO 3166-2:BO">ISO 3166-2:BO</a></span></td>
+          <td>ISO country name follows UN designation (common name and previous ISO country name: <i>Bolivia</i>)</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BQ</span></td>
+          <td><a href="/wiki/Caribbean_Netherlands" title="Caribbean Netherlands">Bonaire, Sint Eustatius and Saba</a>
+          </td>
+          <td>2010</td>
+          <td><a href="/wiki/.bq" title=".bq">.bq</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BQ" title="ISO 3166-2:BQ">ISO 3166-2:BQ</a></span></td>
+          <td>Consists of three Caribbean "<a href="/wiki/Public_body_(Netherlands)" title="Public body (Netherlands)">special
+            municipalities</a>", which are part of the <a href="/wiki/Netherlands" title="Netherlands">Netherlands</a>
+            proper:
+            <a href="/wiki/Bonaire" title="Bonaire">Bonaire</a>, <a href="/wiki/Sint_Eustatius" title="Sint Eustatius">Sint
+              Eustatius</a>, and <a href="/wiki/Saba" title="Saba">Saba</a> (the BES Islands)<br>
+            Previous ISO country name: <i>Bonaire, Saint Eustatius and Saba</i><br>
+            <span style="font-family: monospace, monospace;">BQ</span> previously represented <a
+              href="/wiki/British_Antarctic_Territory" title="British Antarctic Territory">British Antarctic
+              Territory</a>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BR</span></td>
+          <td><a href="/wiki/Brazil" title="Brazil">Brazil</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.br" title=".br">.br</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BR" title="ISO 3166-2:BR">ISO 3166-2:BR</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BS</span></td>
+          <td><a href="/wiki/The_Bahamas" title="The Bahamas">Bahamas</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.bs" title=".bs">.bs</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BS" title="ISO 3166-2:BS">ISO 3166-2:BS</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BT</span></td>
+          <td><a href="/wiki/Bhutan" title="Bhutan">Bhutan</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.bt" title=".bt">.bt</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BT" title="ISO 3166-2:BT">ISO 3166-2:BT</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BV</span></td>
+          <td><a href="/wiki/Bouvet_Island" title="Bouvet Island">Bouvet Island</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.bv" title=".bv">.bv</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BV" title="ISO 3166-2:BV">ISO 3166-2:BV</a></span></td>
+          <td>Belongs to Norway</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BW</span></td>
+          <td><a href="/wiki/Botswana" title="Botswana">Botswana</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.bw" title=".bw">.bw</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BW" title="ISO 3166-2:BW">ISO 3166-2:BW</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BY</span></td>
+          <td><a href="/wiki/Belarus" title="Belarus">Belarus</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.by" title=".by">.by</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BY" title="ISO 3166-2:BY">ISO 3166-2:BY</a></span></td>
+          <td>Code taken from previous ISO country name: <i><a href="/wiki/Byelorussian_Soviet_Socialist_Republic"
+                                                               title="Byelorussian Soviet Socialist Republic">Byelorussian
+            SSR</a></i> (now assigned <a href="/wiki/ISO_3166-3" title="ISO 3166-3">ISO 3166-3</a> code <a
+            href="/wiki/ISO_3166-3#BYAA" title="ISO 3166-3"><span
+            style="font-family: monospace, monospace;">BYAA</span></a>)<br>
+            Code assigned as the country was already a UN member since 1945<sup id="cite_ref-bulletin_16-0"
+                                                                                class="reference"><a
+              href="#cite_note-bulletin-16"><span>[</span>16<span>]</span></a></sup></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">BZ</span></td>
+          <td><a href="/wiki/Belize" title="Belize">Belize</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.bz" title=".bz">.bz</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:BZ" title="ISO 3166-2:BZ">ISO 3166-2:BZ</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CA</span></td>
+          <td><a href="/wiki/Canada" title="Canada">Canada</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ca" title=".ca">.ca</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CA" title="ISO 3166-2:CA">ISO 3166-2:CA</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CC</span></td>
+          <td><a href="/wiki/Cocos_(Keeling)_Islands" title="Cocos (Keeling) Islands">Cocos (Keeling) Islands</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.cc" title=".cc">.cc</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CC" title="ISO 3166-2:CC">ISO 3166-2:CC</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CD</span></td>
+          <td><a href="/wiki/Democratic_Republic_of_the_Congo" title="Democratic Republic of the Congo">Congo, the
+            Democratic
+            Republic of the</a></td>
+          <td>1997</td>
+          <td><a href="/wiki/.cd" title=".cd">.cd</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CD" title="ISO 3166-2:CD">ISO 3166-2:CD</a></span></td>
+          <td>Name changed from <i><a href="/wiki/Zaire" title="Zaire">Zaire</a></i> (<span
+            style="font-family: monospace, monospace;">ZR</span>)
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CF</span></td>
+          <td><a href="/wiki/Central_African_Republic" title="Central African Republic">Central African Republic</a>
+          </td>
+          <td>1974</td>
+          <td><a href="/wiki/.cf" title=".cf">.cf</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CF" title="ISO 3166-2:CF">ISO 3166-2:CF</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CG</span></td>
+          <td><a href="/wiki/Republic_of_the_Congo" title="Republic of the Congo">Congo</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.cg" title=".cg">.cg</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CG" title="ISO 3166-2:CG">ISO 3166-2:CG</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CH</span></td>
+          <td><a href="/wiki/Switzerland" title="Switzerland">Switzerland</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ch" title=".ch">.ch</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CH" title="ISO 3166-2:CH">ISO 3166-2:CH</a></span></td>
+          <td>Code taken from name in <a href="/wiki/Latin_language" title="Latin language"
+                                         class="mw-redirect">Latin</a>:
+            <i><span
+              lang="la" xml:lang="la">Confoederatio Helvetica</span></i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CI</span></td>
+          <td><span style="display:none;" class="sortkey">Cote d'Ivoire !</span><span class="sorttext"><a
+            href="/wiki/Ivory_Coast" title="Ivory Coast">Côte d'Ivoire</a></span></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ci" title=".ci">.ci</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CI" title="ISO 3166-2:CI">ISO 3166-2:CI</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CK</span></td>
+          <td><a href="/wiki/Cook_Islands" title="Cook Islands">Cook Islands</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ck" title=".ck">.ck</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CK" title="ISO 3166-2:CK">ISO 3166-2:CK</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CL</span></td>
+          <td><a href="/wiki/Chile" title="Chile">Chile</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.cl" title=".cl">.cl</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CL" title="ISO 3166-2:CL">ISO 3166-2:CL</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CM</span></td>
+          <td><a href="/wiki/Cameroon" title="Cameroon">Cameroon</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.cm" title=".cm">.cm</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CM" title="ISO 3166-2:CM">ISO 3166-2:CM</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CN</span></td>
+          <td><a href="/wiki/China" title="China">China</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.cn" title=".cn">.cn</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CN" title="ISO 3166-2:CN">ISO 3166-2:CN</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CO</span></td>
+          <td><a href="/wiki/Colombia" title="Colombia">Colombia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.co" title=".co">.co</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CO" title="ISO 3166-2:CO">ISO 3166-2:CO</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CR</span></td>
+          <td><a href="/wiki/Costa_Rica" title="Costa Rica">Costa Rica</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.cr" title=".cr">.cr</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CR" title="ISO 3166-2:CR">ISO 3166-2:CR</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CU</span></td>
+          <td><a href="/wiki/Cuba" title="Cuba">Cuba</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.cu" title=".cu">.cu</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CU" title="ISO 3166-2:CU">ISO 3166-2:CU</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CV</span></td>
+          <td><a href="/wiki/Cabo_Verde" title="Cabo Verde" class="mw-redirect">Cabo Verde</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.cv" title=".cv">.cv</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CV" title="ISO 3166-2:CV">ISO 3166-2:CV</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CW</span></td>
+          <td><a href="/wiki/Cura%C3%A7ao" title="Curaçao">Curaçao</a></td>
+          <td>2010</td>
+          <td><a href="/wiki/.cw" title=".cw">.cw</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CW" title="ISO 3166-2:CW">ISO 3166-2:CW</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CX</span></td>
+          <td><a href="/wiki/Christmas_Island" title="Christmas Island">Christmas Island</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.cx" title=".cx">.cx</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CX" title="ISO 3166-2:CX">ISO 3166-2:CX</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CY</span></td>
+          <td><a href="/wiki/Cyprus" title="Cyprus">Cyprus</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.cy" title=".cy">.cy</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CY" title="ISO 3166-2:CY">ISO 3166-2:CY</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">CZ</span></td>
+          <td><a href="/wiki/Czech_Republic" title="Czech Republic">Czech Republic</a></td>
+          <td>1993</td>
+          <td><a href="/wiki/.cz" title=".cz">.cz</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:CZ" title="ISO 3166-2:CZ">ISO 3166-2:CZ</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">DE</span></td>
+          <td><a href="/wiki/Germany" title="Germany">Germany</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.de" title=".de">.de</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:DE" title="ISO 3166-2:DE">ISO 3166-2:DE</a></span></td>
+          <td>Code taken from name in <a href="/wiki/German_language" title="German language">German</a>: <i><span
+            lang="de"
+            xml:lang="de">Deutschland</span></i><br>
+            Code used for <a href="/wiki/West_Germany" title="West Germany">West Germany</a> before 1990 (previous ISO
+            country
+            name: <i>Germany, Federal Republic of</i>)
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">DJ</span></td>
+          <td><a href="/wiki/Djibouti" title="Djibouti">Djibouti</a></td>
+          <td>1977</td>
+          <td><a href="/wiki/.dj" title=".dj">.dj</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:DJ" title="ISO 3166-2:DJ">ISO 3166-2:DJ</a></span></td>
+          <td>Name changed from <i><a href="/wiki/French_Territory_of_the_Afars_and_the_Issas"
+                                      title="French Territory of the Afars and the Issas">French Afar and Issas</a></i>
+            (<span
+              style="font-family: monospace, monospace;">AI</span>)
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">DK</span></td>
+          <td><a href="/wiki/Denmark" title="Denmark">Denmark</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.dk" title=".dk">.dk</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:DK" title="ISO 3166-2:DK">ISO 3166-2:DK</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">DM</span></td>
+          <td><a href="/wiki/Dominica" title="Dominica">Dominica</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.dm" title=".dm">.dm</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:DM" title="ISO 3166-2:DM">ISO 3166-2:DM</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">DO</span></td>
+          <td><a href="/wiki/Dominican_Republic" title="Dominican Republic">Dominican Republic</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.do" title=".do">.do</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:DO" title="ISO 3166-2:DO">ISO 3166-2:DO</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">DZ</span></td>
+          <td><a href="/wiki/Algeria" title="Algeria">Algeria</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.dz" title=".dz">.dz</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:DZ" title="ISO 3166-2:DZ">ISO 3166-2:DZ</a></span></td>
+          <td>Code taken from name in <a href="/wiki/Kabyle_language" title="Kabyle language">Kabyle</a>: <i><span
+            lang="kab"
+            xml:lang="kab">Dzayer</span></i>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">EC</span></td>
+          <td><a href="/wiki/Ecuador" title="Ecuador">Ecuador</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ec" title=".ec">.ec</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:EC" title="ISO 3166-2:EC">ISO 3166-2:EC</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">EE</span></td>
+          <td><a href="/wiki/Estonia" title="Estonia">Estonia</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.ee" title=".ee">.ee</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:EE" title="ISO 3166-2:EE">ISO 3166-2:EE</a></span></td>
+          <td>Code taken from name in <a href="/wiki/Estonian_language" title="Estonian language">Estonian</a>: <i><span
+            lang="et" xml:lang="et">Eesti</span></i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">EG</span></td>
+          <td><a href="/wiki/Egypt" title="Egypt">Egypt</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.eg" title=".eg">.eg</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:EG" title="ISO 3166-2:EG">ISO 3166-2:EG</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">EH</span></td>
+          <td><a href="/wiki/Western_Sahara" title="Western Sahara">Western Sahara</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.eh" title=".eh">.eh</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:EH" title="ISO 3166-2:EH">ISO 3166-2:EH</a></span></td>
+          <td>Previous ISO country name: <i><a href="/wiki/Spanish_Sahara" title="Spanish Sahara">Spanish Sahara</a></i>
+            (code
+            taken from name in <a href="/wiki/Spanish_language" title="Spanish language">Spanish</a>: <i><span lang="es"
+                                                                                                               xml:lang="es">Sahara español</span></i>)
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">ER</span></td>
+          <td><a href="/wiki/Eritrea" title="Eritrea">Eritrea</a></td>
+          <td>1993</td>
+          <td><a href="/wiki/.er" title=".er">.er</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:ER" title="ISO 3166-2:ER">ISO 3166-2:ER</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">ES</span></td>
+          <td><a href="/wiki/Spain" title="Spain">Spain</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.es" title=".es">.es</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:ES" title="ISO 3166-2:ES">ISO 3166-2:ES</a></span></td>
+          <td>Code taken from name in <a href="/wiki/Spanish_language" title="Spanish language">Spanish</a>: <i><span
+            lang="es" xml:lang="es">España</span></i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">ET</span></td>
+          <td><a href="/wiki/Ethiopia" title="Ethiopia">Ethiopia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.et" title=".et">.et</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:ET" title="ISO 3166-2:ET">ISO 3166-2:ET</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">FI</span></td>
+          <td><a href="/wiki/Finland" title="Finland">Finland</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.fi" title=".fi">.fi</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:FI" title="ISO 3166-2:FI">ISO 3166-2:FI</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">FJ</span></td>
+          <td><a href="/wiki/Fiji" title="Fiji">Fiji</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.fj" title=".fj">.fj</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:FJ" title="ISO 3166-2:FJ">ISO 3166-2:FJ</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">FK</span></td>
+          <td><a href="/wiki/Falkland_Islands" title="Falkland Islands">Falkland Islands (Malvinas)</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.fk" title=".fk">.fk</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:FK" title="ISO 3166-2:FK">ISO 3166-2:FK</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">FM</span></td>
+          <td><a href="/wiki/Federated_States_of_Micronesia" title="Federated States of Micronesia">Micronesia,
+            Federated
+            States of</a></td>
+          <td>1986</td>
+          <td><a href="/wiki/.fm" title=".fm">.fm</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:FM" title="ISO 3166-2:FM">ISO 3166-2:FM</a></span></td>
+          <td>Previous ISO country name: <i>Micronesia</i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">FO</span></td>
+          <td><a href="/wiki/Faroe_Islands" title="Faroe Islands">Faroe Islands</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.fo" title=".fo">.fo</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:FO" title="ISO 3166-2:FO">ISO 3166-2:FO</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">FR</span></td>
+          <td><a href="/wiki/France" title="France">France</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.fr" title=".fr">.fr</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:FR" title="ISO 3166-2:FR">ISO 3166-2:FR</a></span></td>
+          <td>Includes <a href="/wiki/Clipperton_Island" title="Clipperton Island">Clipperton Island</a></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GA</span></td>
+          <td><a href="/wiki/Gabon" title="Gabon">Gabon</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ga" title=".ga">.ga</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GA" title="ISO 3166-2:GA">ISO 3166-2:GA</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GB</span></td>
+          <td><a href="/wiki/United_Kingdom" title="United Kingdom">United Kingdom of Great Britain and Northern
+            Ireland</a>
+          </td>
+          <td>1974</td>
+          <td><a href="/wiki/.gb" title=".gb">.gb</a><br>
+            (<a href="/wiki/.uk" title=".uk">.uk</a>)
+          </td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GB" title="ISO 3166-2:GB">ISO 3166-2:GB</a></span></td>
+          <td>Code taken from <i><a href="/wiki/Great_Britain" title="Great Britain">Great Britain</a></i> (from
+            official
+            name: <i>United Kingdom of Great Britain and Northern Ireland</i>)<sup id="cite_ref-faqs_specific_17-0"
+                                                                                   class="reference"><a
+              href="#cite_note-faqs_specific-17"><span>[</span>17<span>]</span></a></sup><br>
+            <a href="/wiki/.uk" title=".uk">.uk</a> is the primary ccTLD of the United Kingdom instead of <a
+              href="/wiki/.gb"
+              title=".gb">.gb</a>
+            (see code <a href="#UK"><span style="font-family: monospace, monospace;">UK</span></a>, which is <a
+              href="#Exceptional_reservations">exceptionally reserved</a>)
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GD</span></td>
+          <td><a href="/wiki/Grenada" title="Grenada">Grenada</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.gd" title=".gd">.gd</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GD" title="ISO 3166-2:GD">ISO 3166-2:GD</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GE</span></td>
+          <td><a href="/wiki/Georgia_(country)" title="Georgia (country)">Georgia</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.ge" title=".ge">.ge</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GE" title="ISO 3166-2:GE">ISO 3166-2:GE</a></span></td>
+          <td><span style="font-family: monospace, monospace;">GE</span> previously represented <a
+            href="/wiki/Gilbert_and_Ellice_Islands" title="Gilbert and Ellice Islands">Gilbert and Ellice Islands</a>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GF</span></td>
+          <td><a href="/wiki/French_Guiana" title="French Guiana">French Guiana</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.gf" title=".gf">.gf</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GF" title="ISO 3166-2:GF">ISO 3166-2:GF</a></span></td>
+          <td>Code taken from name in <a href="/wiki/French_language" title="French language">French</a>: <i><span
+            lang="fr"
+            xml:lang="fr">Guyane française</span></i>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GG</span></td>
+          <td><a href="/wiki/Guernsey" title="Guernsey">Guernsey</a></td>
+          <td>2006</td>
+          <td><a href="/wiki/.gg" title=".gg">.gg</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GG" title="ISO 3166-2:GG">ISO 3166-2:GG</a></span></td>
+          <td>a <a href="/wiki/United_Kingdom" title="United Kingdom">British</a> <a href="/wiki/Crown_dependency"
+                                                                                     title="Crown dependency"
+                                                                                     class="mw-redirect">Crown
+            dependency</a>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GH</span></td>
+          <td><a href="/wiki/Ghana" title="Ghana">Ghana</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.gh" title=".gh">.gh</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GH" title="ISO 3166-2:GH">ISO 3166-2:GH</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GI</span></td>
+          <td><a href="/wiki/Gibraltar" title="Gibraltar">Gibraltar</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.gi" title=".gi">.gi</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GI" title="ISO 3166-2:GI">ISO 3166-2:GI</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GL</span></td>
+          <td><a href="/wiki/Greenland" title="Greenland">Greenland</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.gl" title=".gl">.gl</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GL" title="ISO 3166-2:GL">ISO 3166-2:GL</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GM</span></td>
+          <td><a href="/wiki/The_Gambia" title="The Gambia">Gambia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.gm" title=".gm">.gm</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GM" title="ISO 3166-2:GM">ISO 3166-2:GM</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GN</span></td>
+          <td><a href="/wiki/Guinea" title="Guinea">Guinea</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.gn" title=".gn">.gn</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GN" title="ISO 3166-2:GN">ISO 3166-2:GN</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GP</span></td>
+          <td><a href="/wiki/Guadeloupe" title="Guadeloupe">Guadeloupe</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.gp" title=".gp">.gp</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GP" title="ISO 3166-2:GP">ISO 3166-2:GP</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GQ</span></td>
+          <td><a href="/wiki/Equatorial_Guinea" title="Equatorial Guinea">Equatorial Guinea</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.gq" title=".gq">.gq</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GQ" title="ISO 3166-2:GQ">ISO 3166-2:GQ</a></span></td>
+          <td>Code taken from name in <a href="/wiki/French_language" title="French language">French</a>: <i><span
+            lang="fr"
+            xml:lang="fr">Guinée équatoriale</span></i>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GR</span></td>
+          <td><a href="/wiki/Greece" title="Greece">Greece</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.gr" title=".gr">.gr</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GR" title="ISO 3166-2:GR">ISO 3166-2:GR</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GS</span></td>
+          <td><a href="/wiki/South_Georgia_and_the_South_Sandwich_Islands"
+                 title="South Georgia and the South Sandwich Islands">South Georgia and the South Sandwich Islands</a>
+          </td>
+          <td>1993</td>
+          <td><a href="/wiki/.gs" title=".gs">.gs</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GS" title="ISO 3166-2:GS">ISO 3166-2:GS</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GT</span></td>
+          <td><a href="/wiki/Guatemala" title="Guatemala">Guatemala</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.gt" title=".gt">.gt</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GT" title="ISO 3166-2:GT">ISO 3166-2:GT</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GU</span></td>
+          <td><a href="/wiki/Guam" title="Guam">Guam</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.gu" title=".gu">.gu</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GU" title="ISO 3166-2:GU">ISO 3166-2:GU</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GW</span></td>
+          <td><a href="/wiki/Guinea-Bissau" title="Guinea-Bissau">Guinea-Bissau</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.gw" title=".gw">.gw</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GW" title="ISO 3166-2:GW">ISO 3166-2:GW</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">GY</span></td>
+          <td><a href="/wiki/Guyana" title="Guyana">Guyana</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.gy" title=".gy">.gy</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:GY" title="ISO 3166-2:GY">ISO 3166-2:GY</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">HK</span></td>
+          <td><a href="/wiki/Hong_Kong" title="Hong Kong">Hong Kong</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.hk" title=".hk">.hk</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:HK" title="ISO 3166-2:HK">ISO 3166-2:HK</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">HM</span></td>
+          <td><a href="/wiki/Heard_Island_and_McDonald_Islands" title="Heard Island and McDonald Islands">Heard Island
+            and
+            McDonald Islands</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.hm" title=".hm">.hm</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:HM" title="ISO 3166-2:HM">ISO 3166-2:HM</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">HN</span></td>
+          <td><a href="/wiki/Honduras" title="Honduras">Honduras</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.hn" title=".hn">.hn</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:HN" title="ISO 3166-2:HN">ISO 3166-2:HN</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">HR</span></td>
+          <td><a href="/wiki/Croatia" title="Croatia">Croatia</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.hr" title=".hr">.hr</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:HR" title="ISO 3166-2:HR">ISO 3166-2:HR</a></span></td>
+          <td>Code taken from name in <a href="/wiki/Croatian_language" title="Croatian language">Croatian</a>: <i><span
+            lang="hr" xml:lang="hr">Hrvatska</span></i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">HT</span></td>
+          <td><a href="/wiki/Haiti" title="Haiti">Haiti</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ht" title=".ht">.ht</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:HT" title="ISO 3166-2:HT">ISO 3166-2:HT</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">HU</span></td>
+          <td><a href="/wiki/Hungary" title="Hungary">Hungary</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.hu" title=".hu">.hu</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:HU" title="ISO 3166-2:HU">ISO 3166-2:HU</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">ID</span></td>
+          <td><a href="/wiki/Indonesia" title="Indonesia">Indonesia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.id" title=".id">.id</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:ID" title="ISO 3166-2:ID">ISO 3166-2:ID</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">IE</span></td>
+          <td><a href="/wiki/Republic_of_Ireland" title="Republic of Ireland">Ireland</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ie" title=".ie">.ie</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:IE" title="ISO 3166-2:IE">ISO 3166-2:IE</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">IL</span></td>
+          <td><a href="/wiki/Israel" title="Israel">Israel</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.il" title=".il">.il</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:IL" title="ISO 3166-2:IL">ISO 3166-2:IL</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">IM</span></td>
+          <td><a href="/wiki/Isle_of_Man" title="Isle of Man">Isle of Man</a></td>
+          <td>2006</td>
+          <td><a href="/wiki/.im" title=".im">.im</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:IM" title="ISO 3166-2:IM">ISO 3166-2:IM</a></span></td>
+          <td>a <a href="/wiki/United_Kingdom" title="United Kingdom">British</a> <a href="/wiki/Crown_dependency"
+                                                                                     title="Crown dependency"
+                                                                                     class="mw-redirect">Crown
+            dependency</a>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">IN</span></td>
+          <td><a href="/wiki/India" title="India">India</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.in" title=".in">.in</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:IN" title="ISO 3166-2:IN">ISO 3166-2:IN</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">IO</span></td>
+          <td><a href="/wiki/British_Indian_Ocean_Territory" title="British Indian Ocean Territory">British Indian Ocean
+            Territory</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.io" title=".io">.io</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:IO" title="ISO 3166-2:IO">ISO 3166-2:IO</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">IQ</span></td>
+          <td><a href="/wiki/Iraq" title="Iraq">Iraq</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.iq" title=".iq">.iq</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:IQ" title="ISO 3166-2:IQ">ISO 3166-2:IQ</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">IR</span></td>
+          <td><a href="/wiki/Iran" title="Iran">Iran, Islamic Republic of</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ir" title=".ir">.ir</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:IR" title="ISO 3166-2:IR">ISO 3166-2:IR</a></span></td>
+          <td>ISO country name follows UN designation (common name: <i>Iran</i>)</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">IS</span></td>
+          <td><a href="/wiki/Iceland" title="Iceland">Iceland</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.is" title=".is">.is</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:IS" title="ISO 3166-2:IS">ISO 3166-2:IS</a></span></td>
+          <td>Code taken from name in <a href="/wiki/Icelandic_language" title="Icelandic language">Icelandic</a>:
+            <i><span
+              lang="is" xml:lang="is">Ísland</span></i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">IT</span></td>
+          <td><a href="/wiki/Italy" title="Italy">Italy</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.it" title=".it">.it</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:IT" title="ISO 3166-2:IT">ISO 3166-2:IT</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">JE</span></td>
+          <td><a href="/wiki/Jersey" title="Jersey">Jersey</a></td>
+          <td>2006</td>
+          <td><a href="/wiki/.je" title=".je">.je</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:JE" title="ISO 3166-2:JE">ISO 3166-2:JE</a></span></td>
+          <td>a <a href="/wiki/United_Kingdom" title="United Kingdom">British</a> <a href="/wiki/Crown_dependency"
+                                                                                     title="Crown dependency"
+                                                                                     class="mw-redirect">Crown
+            dependency</a>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">JM</span></td>
+          <td><a href="/wiki/Jamaica" title="Jamaica">Jamaica</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.jm" title=".jm">.jm</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:JM" title="ISO 3166-2:JM">ISO 3166-2:JM</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">JO</span></td>
+          <td><a href="/wiki/Jordan" title="Jordan">Jordan</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.jo" title=".jo">.jo</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:JO" title="ISO 3166-2:JO">ISO 3166-2:JO</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">JP</span></td>
+          <td><a href="/wiki/Japan" title="Japan">Japan</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.jp" title=".jp">.jp</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:JP" title="ISO 3166-2:JP">ISO 3166-2:JP</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">KE</span></td>
+          <td><a href="/wiki/Kenya" title="Kenya">Kenya</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ke" title=".ke">.ke</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:KE" title="ISO 3166-2:KE">ISO 3166-2:KE</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">KG</span></td>
+          <td><a href="/wiki/Kyrgyzstan" title="Kyrgyzstan">Kyrgyzstan</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.kg" title=".kg">.kg</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:KG" title="ISO 3166-2:KG">ISO 3166-2:KG</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">KH</span></td>
+          <td><a href="/wiki/Cambodia" title="Cambodia">Cambodia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.kh" title=".kh">.kh</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:KH" title="ISO 3166-2:KH">ISO 3166-2:KH</a></span></td>
+          <td>Code taken from former name: <i><a href="/wiki/Khmer_Republic" title="Khmer Republic">Khmer
+            Republic</a></i><br>
+            Previous ISO country name: <i><a href="/wiki/Democratic_Kampuchea"
+                                             title="Democratic Kampuchea">Kampuchea</a></i>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">KI</span></td>
+          <td><a href="/wiki/Kiribati" title="Kiribati">Kiribati</a></td>
+          <td>1979</td>
+          <td><a href="/wiki/.ki" title=".ki">.ki</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:KI" title="ISO 3166-2:KI">ISO 3166-2:KI</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">KM</span></td>
+          <td><a href="/wiki/Comoros" title="Comoros">Comoros</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.km" title=".km">.km</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:KM" title="ISO 3166-2:KM">ISO 3166-2:KM</a></span></td>
+          <td>Code taken from name in <a href="/wiki/Comorian_language" title="Comorian language">Comorian</a>: <i><span
+            lang="bnt" xml:lang="bnt">Komori</span></i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">KN</span></td>
+          <td><a href="/wiki/Saint_Kitts_and_Nevis" title="Saint Kitts and Nevis">Saint Kitts and Nevis</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.kn" title=".kn">.kn</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:KN" title="ISO 3166-2:KN">ISO 3166-2:KN</a></span></td>
+          <td>Previous ISO country name: <i><a href="/wiki/Saint_Christopher-Nevis-Anguilla"
+                                               title="Saint Christopher-Nevis-Anguilla">Saint
+            Kitts-Nevis-Anguilla</a></i>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">KP</span></td>
+          <td><a href="/wiki/North_Korea" title="North Korea">Korea, Democratic People's Republic of</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.kp" title=".kp">.kp</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:KP" title="ISO 3166-2:KP">ISO 3166-2:KP</a></span></td>
+          <td>ISO country name follows UN designation (common name: <i>North Korea</i>)</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">KR</span></td>
+          <td><a href="/wiki/South_Korea" title="South Korea">Korea, Republic of</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.kr" title=".kr">.kr</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:KR" title="ISO 3166-2:KR">ISO 3166-2:KR</a></span></td>
+          <td>ISO country name follows UN designation (common name: <i>South Korea</i>)</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">KW</span></td>
+          <td><a href="/wiki/Kuwait" title="Kuwait">Kuwait</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.kw" title=".kw">.kw</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:KW" title="ISO 3166-2:KW">ISO 3166-2:KW</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">KY</span></td>
+          <td><a href="/wiki/Cayman_Islands" title="Cayman Islands">Cayman Islands</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ky" title=".ky">.ky</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:KY" title="ISO 3166-2:KY">ISO 3166-2:KY</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">KZ</span></td>
+          <td><a href="/wiki/Kazakhstan" title="Kazakhstan">Kazakhstan</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.kz" title=".kz">.kz</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:KZ" title="ISO 3166-2:KZ">ISO 3166-2:KZ</a></span></td>
+          <td>Previous ISO country name: <i>Kazakstan</i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">LA</span></td>
+          <td><a href="/wiki/Laos" title="Laos">Lao People's Democratic Republic</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.la" title=".la">.la</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:LA" title="ISO 3166-2:LA">ISO 3166-2:LA</a></span></td>
+          <td>ISO country name follows UN designation (common name: <i>Laos</i>)</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">LB</span></td>
+          <td><a href="/wiki/Lebanon" title="Lebanon">Lebanon</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.lb" title=".lb">.lb</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:LB" title="ISO 3166-2:LB">ISO 3166-2:LB</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">LC</span></td>
+          <td><a href="/wiki/Saint_Lucia" title="Saint Lucia">Saint Lucia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.lc" title=".lc">.lc</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:LC" title="ISO 3166-2:LC">ISO 3166-2:LC</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">LI</span></td>
+          <td><a href="/wiki/Liechtenstein" title="Liechtenstein">Liechtenstein</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.li" title=".li">.li</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:LI" title="ISO 3166-2:LI">ISO 3166-2:LI</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">LK</span></td>
+          <td><a href="/wiki/Sri_Lanka" title="Sri Lanka">Sri Lanka</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.lk" title=".lk">.lk</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:LK" title="ISO 3166-2:LK">ISO 3166-2:LK</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">LR</span></td>
+          <td><a href="/wiki/Liberia" title="Liberia">Liberia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.lr" title=".lr">.lr</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:LR" title="ISO 3166-2:LR">ISO 3166-2:LR</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">LS</span></td>
+          <td><a href="/wiki/Lesotho" title="Lesotho">Lesotho</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ls" title=".ls">.ls</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:LS" title="ISO 3166-2:LS">ISO 3166-2:LS</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">LT</span></td>
+          <td><a href="/wiki/Lithuania" title="Lithuania">Lithuania</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.lt" title=".lt">.lt</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:LT" title="ISO 3166-2:LT">ISO 3166-2:LT</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">LU</span></td>
+          <td><a href="/wiki/Luxembourg" title="Luxembourg">Luxembourg</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.lu" title=".lu">.lu</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:LU" title="ISO 3166-2:LU">ISO 3166-2:LU</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">LV</span></td>
+          <td><a href="/wiki/Latvia" title="Latvia">Latvia</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.lv" title=".lv">.lv</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:LV" title="ISO 3166-2:LV">ISO 3166-2:LV</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">LY</span></td>
+          <td><a href="/wiki/Libya" title="Libya">Libya</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ly" title=".ly">.ly</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:LY" title="ISO 3166-2:LY">ISO 3166-2:LY</a></span></td>
+          <td>Previous ISO country name: <i><a href="/wiki/Libyan_Arab_Jamahiriya" title="Libyan Arab Jamahiriya"
+                                               class="mw-redirect">Libyan Arab Jamahiriya</a></i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MA</span></td>
+          <td><a href="/wiki/Morocco" title="Morocco">Morocco</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ma" title=".ma">.ma</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MA" title="ISO 3166-2:MA">ISO 3166-2:MA</a></span></td>
+          <td>Code taken from name in <a href="/wiki/French_language" title="French language">French</a>: <i><span
+            lang="fr"
+            xml:lang="fr">Maroc</span></i>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MC</span></td>
+          <td><a href="/wiki/Monaco" title="Monaco">Monaco</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.mc" title=".mc">.mc</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MC" title="ISO 3166-2:MC">ISO 3166-2:MC</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MD</span></td>
+          <td><a href="/wiki/Moldova" title="Moldova">Moldova, Republic of</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.md" title=".md">.md</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MD" title="ISO 3166-2:MD">ISO 3166-2:MD</a></span></td>
+          <td>ISO country name follows UN designation (common name and previous ISO country name: <i>Moldova</i>)</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">ME</span></td>
+          <td><a href="/wiki/Montenegro" title="Montenegro">Montenegro</a></td>
+          <td>2006</td>
+          <td><a href="/wiki/.me" title=".me">.me</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:ME" title="ISO 3166-2:ME">ISO 3166-2:ME</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MF</span></td>
+          <td><a href="/wiki/Collectivity_of_Saint_Martin" title="Collectivity of Saint Martin">Saint Martin (French
+            part)</a>
+          </td>
+          <td>2007</td>
+          <td><a href="/wiki/.mf" title=".mf" class="mw-redirect">.mf</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MF" title="ISO 3166-2:MF">ISO 3166-2:MF</a></span></td>
+          <td>The <a href="/wiki/Sint_Maarten" title="Sint Maarten">Dutch part</a> of <a href="/wiki/Saint_Martin"
+                                                                                         title="Saint Martin">Saint
+            Martin</a>
+            island is assigned code <a href="#SX"><span style="font-family: monospace, monospace;">SX</span></a></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MG</span></td>
+          <td><a href="/wiki/Madagascar" title="Madagascar">Madagascar</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.mg" title=".mg">.mg</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MG" title="ISO 3166-2:MG">ISO 3166-2:MG</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MH</span></td>
+          <td><a href="/wiki/Marshall_Islands" title="Marshall Islands">Marshall Islands</a></td>
+          <td>1986</td>
+          <td><a href="/wiki/.mh" title=".mh">.mh</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MH" title="ISO 3166-2:MH">ISO 3166-2:MH</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MK</span></td>
+          <td><a href="/wiki/Republic_of_Macedonia" title="Republic of Macedonia">Macedonia, the former Yugoslav
+            Republic
+            of</a></td>
+          <td>1993</td>
+          <td><a href="/wiki/.mk" title=".mk">.mk</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MK" title="ISO 3166-2:MK">ISO 3166-2:MK</a></span></td>
+          <td>ISO country name follows UN designation (due to <a href="/wiki/Macedonia_naming_dispute"
+                                                                 title="Macedonia naming dispute">Macedonia naming
+            dispute</a>;
+            official name used by country itself: <i>Republic of Macedonia</i>)<br>
+            Code taken from name in <a href="/wiki/Macedonian_language" title="Macedonian language">Macedonian</a>:
+            <i><span
+              lang="mk" xml:lang="mk">Makedonija</span></i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">ML</span></td>
+          <td><a href="/wiki/Mali" title="Mali">Mali</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ml" title=".ml">.ml</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:ML" title="ISO 3166-2:ML">ISO 3166-2:ML</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MM</span></td>
+          <td><a href="/wiki/Myanmar" title="Myanmar">Myanmar</a></td>
+          <td>1989</td>
+          <td><a href="/wiki/.mm" title=".mm">.mm</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MM" title="ISO 3166-2:MM">ISO 3166-2:MM</a></span></td>
+          <td>Name changed from <i>Burma</i> (<span style="font-family: monospace, monospace;">BU</span>)</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MN</span></td>
+          <td><a href="/wiki/Mongolia" title="Mongolia">Mongolia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.mn" title=".mn">.mn</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MN" title="ISO 3166-2:MN">ISO 3166-2:MN</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MO</span></td>
+          <td><a href="/wiki/Macau" title="Macau">Macao</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.mo" title=".mo">.mo</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MO" title="ISO 3166-2:MO">ISO 3166-2:MO</a></span></td>
+          <td>Previous ISO country name: <i>Macau</i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MP</span></td>
+          <td><a href="/wiki/Northern_Mariana_Islands" title="Northern Mariana Islands">Northern Mariana Islands</a>
+          </td>
+          <td>1986</td>
+          <td><a href="/wiki/.mp" title=".mp">.mp</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MP" title="ISO 3166-2:MP">ISO 3166-2:MP</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MQ</span></td>
+          <td><a href="/wiki/Martinique" title="Martinique">Martinique</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.mq" title=".mq">.mq</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MQ" title="ISO 3166-2:MQ">ISO 3166-2:MQ</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MR</span></td>
+          <td><a href="/wiki/Mauritania" title="Mauritania">Mauritania</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.mr" title=".mr">.mr</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MR" title="ISO 3166-2:MR">ISO 3166-2:MR</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MS</span></td>
+          <td><a href="/wiki/Montserrat" title="Montserrat">Montserrat</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ms" title=".ms">.ms</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MS" title="ISO 3166-2:MS">ISO 3166-2:MS</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MT</span></td>
+          <td><a href="/wiki/Malta" title="Malta">Malta</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.mt" title=".mt">.mt</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MT" title="ISO 3166-2:MT">ISO 3166-2:MT</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MU</span></td>
+          <td><a href="/wiki/Mauritius" title="Mauritius">Mauritius</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.mu" title=".mu">.mu</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MU" title="ISO 3166-2:MU">ISO 3166-2:MU</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MV</span></td>
+          <td><a href="/wiki/Maldives" title="Maldives">Maldives</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.mv" title=".mv">.mv</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MV" title="ISO 3166-2:MV">ISO 3166-2:MV</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MW</span></td>
+          <td><a href="/wiki/Malawi" title="Malawi">Malawi</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.mw" title=".mw">.mw</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MW" title="ISO 3166-2:MW">ISO 3166-2:MW</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MX</span></td>
+          <td><a href="/wiki/Mexico" title="Mexico">Mexico</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.mx" title=".mx">.mx</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MX" title="ISO 3166-2:MX">ISO 3166-2:MX</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MY</span></td>
+          <td><a href="/wiki/Malaysia" title="Malaysia">Malaysia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.my" title=".my">.my</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MY" title="ISO 3166-2:MY">ISO 3166-2:MY</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">MZ</span></td>
+          <td><a href="/wiki/Mozambique" title="Mozambique">Mozambique</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.mz" title=".mz">.mz</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:MZ" title="ISO 3166-2:MZ">ISO 3166-2:MZ</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">NA</span></td>
+          <td><a href="/wiki/Namibia" title="Namibia">Namibia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.na" title=".na">.na</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:NA" title="ISO 3166-2:NA">ISO 3166-2:NA</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">NC</span></td>
+          <td><a href="/wiki/New_Caledonia" title="New Caledonia">New Caledonia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.nc" title=".nc">.nc</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:NC" title="ISO 3166-2:NC">ISO 3166-2:NC</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">NE</span></td>
+          <td><a href="/wiki/Niger" title="Niger">Niger</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ne" title=".ne">.ne</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:NE" title="ISO 3166-2:NE">ISO 3166-2:NE</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">NF</span></td>
+          <td><a href="/wiki/Norfolk_Island" title="Norfolk Island">Norfolk Island</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.nf" title=".nf">.nf</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:NF" title="ISO 3166-2:NF">ISO 3166-2:NF</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">NG</span></td>
+          <td><a href="/wiki/Nigeria" title="Nigeria">Nigeria</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ng" title=".ng">.ng</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:NG" title="ISO 3166-2:NG">ISO 3166-2:NG</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">NI</span></td>
+          <td><a href="/wiki/Nicaragua" title="Nicaragua">Nicaragua</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ni" title=".ni">.ni</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:NI" title="ISO 3166-2:NI">ISO 3166-2:NI</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">NL</span></td>
+          <td><a href="/wiki/Netherlands" title="Netherlands">Netherlands</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.nl" title=".nl">.nl</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:NL" title="ISO 3166-2:NL">ISO 3166-2:NL</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">NO</span></td>
+          <td><a href="/wiki/Norway" title="Norway">Norway</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.no" title=".no">.no</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:NO" title="ISO 3166-2:NO">ISO 3166-2:NO</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">NP</span></td>
+          <td><a href="/wiki/Nepal" title="Nepal">Nepal</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.np" title=".np">.np</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:NP" title="ISO 3166-2:NP">ISO 3166-2:NP</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">NR</span></td>
+          <td><a href="/wiki/Nauru" title="Nauru">Nauru</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.nr" title=".nr">.nr</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:NR" title="ISO 3166-2:NR">ISO 3166-2:NR</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">NU</span></td>
+          <td><a href="/wiki/Niue" title="Niue">Niue</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.nu" title=".nu">.nu</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:NU" title="ISO 3166-2:NU">ISO 3166-2:NU</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">NZ</span></td>
+          <td><a href="/wiki/New_Zealand" title="New Zealand">New Zealand</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.nz" title=".nz">.nz</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:NZ" title="ISO 3166-2:NZ">ISO 3166-2:NZ</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">OM</span></td>
+          <td><a href="/wiki/Oman" title="Oman">Oman</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.om" title=".om">.om</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:OM" title="ISO 3166-2:OM">ISO 3166-2:OM</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">PA</span></td>
+          <td><a href="/wiki/Panama" title="Panama">Panama</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.pa" title=".pa">.pa</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:PA" title="ISO 3166-2:PA">ISO 3166-2:PA</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">PE</span></td>
+          <td><a href="/wiki/Peru" title="Peru">Peru</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.pe" title=".pe">.pe</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:PE" title="ISO 3166-2:PE">ISO 3166-2:PE</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">PF</span></td>
+          <td><a href="/wiki/French_Polynesia" title="French Polynesia">French Polynesia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.pf" title=".pf">.pf</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:PF" title="ISO 3166-2:PF">ISO 3166-2:PF</a></span></td>
+          <td>Code taken from name in <a href="/wiki/French_language" title="French language">French</a>: <i><span
+            lang="fr"
+            xml:lang="fr">Polynésie française</span></i>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">PG</span></td>
+          <td><a href="/wiki/Papua_New_Guinea" title="Papua New Guinea">Papua New Guinea</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.pg" title=".pg">.pg</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:PG" title="ISO 3166-2:PG">ISO 3166-2:PG</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">PH</span></td>
+          <td><a href="/wiki/Philippines" title="Philippines">Philippines</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ph" title=".ph">.ph</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:PH" title="ISO 3166-2:PH">ISO 3166-2:PH</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">PK</span></td>
+          <td><a href="/wiki/Pakistan" title="Pakistan">Pakistan</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.pk" title=".pk">.pk</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:PK" title="ISO 3166-2:PK">ISO 3166-2:PK</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">PL</span></td>
+          <td><a href="/wiki/Poland" title="Poland">Poland</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.pl" title=".pl">.pl</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:PL" title="ISO 3166-2:PL">ISO 3166-2:PL</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">PM</span></td>
+          <td><a href="/wiki/Saint_Pierre_and_Miquelon" title="Saint Pierre and Miquelon">Saint Pierre and Miquelon</a>
+          </td>
+          <td>1974</td>
+          <td><a href="/wiki/.pm" title=".pm">.pm</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:PM" title="ISO 3166-2:PM">ISO 3166-2:PM</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">PN</span></td>
+          <td><a href="/wiki/Pitcairn_Islands" title="Pitcairn Islands">Pitcairn</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.pn" title=".pn">.pn</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:PN" title="ISO 3166-2:PN">ISO 3166-2:PN</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">PR</span></td>
+          <td><a href="/wiki/Puerto_Rico" title="Puerto Rico">Puerto Rico</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.pr" title=".pr">.pr</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:PR" title="ISO 3166-2:PR">ISO 3166-2:PR</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">PS</span></td>
+          <td><a href="/wiki/State_of_Palestine" title="State of Palestine">Palestine, State of</a></td>
+          <td>2013</td>
+          <td><a href="/wiki/.ps" title=".ps">.ps</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:PS" title="ISO 3166-2:PS">ISO 3166-2:PS</a></span></td>
+          <td>Previous ISO country name: <i><a href="/wiki/Palestinian_territories" title="Palestinian territories">Palestinian
+            Territory, Occupied</a></i><br>
+            Consists of the <a href="/wiki/West_Bank" title="West Bank">West Bank</a> and the <a href="/wiki/Gaza_Strip"
+                                                                                                 title="Gaza Strip">Gaza
+              Strip</a></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">PT</span></td>
+          <td><a href="/wiki/Portugal" title="Portugal">Portugal</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.pt" title=".pt">.pt</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:PT" title="ISO 3166-2:PT">ISO 3166-2:PT</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">PW</span></td>
+          <td><a href="/wiki/Palau" title="Palau">Palau</a></td>
+          <td>1986</td>
+          <td><a href="/wiki/.pw" title=".pw">.pw</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:PW" title="ISO 3166-2:PW">ISO 3166-2:PW</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">PY</span></td>
+          <td><a href="/wiki/Paraguay" title="Paraguay">Paraguay</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.py" title=".py">.py</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:PY" title="ISO 3166-2:PY">ISO 3166-2:PY</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">QA</span></td>
+          <td><a href="/wiki/Qatar" title="Qatar">Qatar</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.qa" title=".qa">.qa</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:QA" title="ISO 3166-2:QA">ISO 3166-2:QA</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">RE</span></td>
+          <td><span style="display:none;" class="sortkey">Reunion !</span><span class="sorttext"><a
+            href="/wiki/R%C3%A9union"
+            title="Réunion">Réunion</a></span>
+          </td>
+          <td>1974</td>
+          <td><a href="/wiki/.re" title=".re">.re</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:RE" title="ISO 3166-2:RE">ISO 3166-2:RE</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">RO</span></td>
+          <td><a href="/wiki/Romania" title="Romania">Romania</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ro" title=".ro">.ro</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:RO" title="ISO 3166-2:RO">ISO 3166-2:RO</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">RS</span></td>
+          <td><a href="/wiki/Serbia" title="Serbia">Serbia</a></td>
+          <td>2006</td>
+          <td><a href="/wiki/.rs" title=".rs">.rs</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:RS" title="ISO 3166-2:RS">ISO 3166-2:RS</a></span></td>
+          <td>Code taken from official name: <i>Republic of Serbia</i> <i>(see <a href="/wiki/Serbian_country_codes"
+                                                                                  title="Serbian country codes"
+                                                                                  class="mw-redirect">Serbian country
+            codes</a>)</i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">RU</span></td>
+          <td><a href="/wiki/Russia" title="Russia">Russian Federation</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.ru" title=".ru">.ru</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:RU" title="ISO 3166-2:RU">ISO 3166-2:RU</a></span></td>
+          <td>ISO country name follows UN designation (common name: <i>Russia</i>)</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">RW</span></td>
+          <td><a href="/wiki/Rwanda" title="Rwanda">Rwanda</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.rw" title=".rw">.rw</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:RW" title="ISO 3166-2:RW">ISO 3166-2:RW</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SA</span></td>
+          <td><a href="/wiki/Saudi_Arabia" title="Saudi Arabia">Saudi Arabia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.sa" title=".sa">.sa</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SA" title="ISO 3166-2:SA">ISO 3166-2:SA</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SB</span></td>
+          <td><a href="/wiki/Solomon_Islands" title="Solomon Islands">Solomon Islands</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.sb" title=".sb">.sb</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SB" title="ISO 3166-2:SB">ISO 3166-2:SB</a></span></td>
+          <td>Code taken from former name: <i>British Solomon Islands</i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SC</span></td>
+          <td><a href="/wiki/Seychelles" title="Seychelles">Seychelles</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.sc" title=".sc">.sc</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SC" title="ISO 3166-2:SC">ISO 3166-2:SC</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SD</span></td>
+          <td><a href="/wiki/Sudan" title="Sudan">Sudan</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.sd" title=".sd">.sd</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SD" title="ISO 3166-2:SD">ISO 3166-2:SD</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SE</span></td>
+          <td><a href="/wiki/Sweden" title="Sweden">Sweden</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.se" title=".se">.se</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SE" title="ISO 3166-2:SE">ISO 3166-2:SE</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SG</span></td>
+          <td><a href="/wiki/Singapore" title="Singapore">Singapore</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.sg" title=".sg">.sg</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SG" title="ISO 3166-2:SG">ISO 3166-2:SG</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SH</span></td>
+          <td><a href="/wiki/Saint_Helena,_Ascension_and_Tristan_da_Cunha"
+                 title="Saint Helena, Ascension and Tristan da Cunha">Saint Helena, Ascension and Tristan da Cunha</a>
+          </td>
+          <td>1974</td>
+          <td><a href="/wiki/.sh" title=".sh">.sh</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SH" title="ISO 3166-2:SH">ISO 3166-2:SH</a></span></td>
+          <td>Previous ISO country name: <i><a href="/wiki/Saint_Helena" title="Saint Helena">Saint Helena</a></i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SI</span></td>
+          <td><a href="/wiki/Slovenia" title="Slovenia">Slovenia</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.si" title=".si">.si</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SI" title="ISO 3166-2:SI">ISO 3166-2:SI</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SJ</span></td>
+          <td><a href="/wiki/Svalbard_and_Jan_Mayen" title="Svalbard and Jan Mayen">Svalbard and Jan Mayen</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.sj" title=".sj">.sj</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SJ" title="ISO 3166-2:SJ">ISO 3166-2:SJ</a></span></td>
+          <td>Consists of two arctic territories of Norway: <a href="/wiki/Svalbard" title="Svalbard">Svalbard</a> and
+            <a
+              href="/wiki/Jan_Mayen" title="Jan Mayen">Jan Mayen</a></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SK</span></td>
+          <td><a href="/wiki/Slovakia" title="Slovakia">Slovakia</a></td>
+          <td>1993</td>
+          <td><a href="/wiki/.sk" title=".sk">.sk</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SK" title="ISO 3166-2:SK">ISO 3166-2:SK</a></span></td>
+          <td><span style="font-family: monospace, monospace;">SK</span> previously represented <a href="/wiki/Sikkim"
+                                                                                                   title="Sikkim">Sikkim</a>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SL</span></td>
+          <td><a href="/wiki/Sierra_Leone" title="Sierra Leone">Sierra Leone</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.sl" title=".sl">.sl</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SL" title="ISO 3166-2:SL">ISO 3166-2:SL</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SM</span></td>
+          <td><a href="/wiki/San_Marino" title="San Marino">San Marino</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.sm" title=".sm">.sm</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SM" title="ISO 3166-2:SM">ISO 3166-2:SM</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SN</span></td>
+          <td><a href="/wiki/Senegal" title="Senegal">Senegal</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.sn" title=".sn">.sn</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SN" title="ISO 3166-2:SN">ISO 3166-2:SN</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SO</span></td>
+          <td><a href="/wiki/Somalia" title="Somalia">Somalia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.so" title=".so">.so</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SO" title="ISO 3166-2:SO">ISO 3166-2:SO</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SR</span></td>
+          <td><a href="/wiki/Suriname" title="Suriname">Suriname</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.sr" title=".sr">.sr</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SR" title="ISO 3166-2:SR">ISO 3166-2:SR</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SS</span></td>
+          <td><a href="/wiki/South_Sudan" title="South Sudan">South Sudan</a></td>
+          <td>2011</td>
+          <td><a href="/wiki/.ss" title=".ss">.ss</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SS" title="ISO 3166-2:SS">ISO 3166-2:SS</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">ST</span></td>
+          <td><a href="/wiki/S%C3%A3o_Tom%C3%A9_and_Pr%C3%ADncipe" title="São Tomé and Príncipe">Sao Tome and
+            Principe</a>
+          </td>
+          <td>1974</td>
+          <td><a href="/wiki/.st" title=".st">.st</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:ST" title="ISO 3166-2:ST">ISO 3166-2:ST</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SV</span></td>
+          <td><a href="/wiki/El_Salvador" title="El Salvador">El Salvador</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.sv" title=".sv">.sv</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SV" title="ISO 3166-2:SV">ISO 3166-2:SV</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SX</span></td>
+          <td><a href="/wiki/Sint_Maarten" title="Sint Maarten">Sint Maarten (Dutch part)</a></td>
+          <td>2010</td>
+          <td><a href="/wiki/.sx" title=".sx">.sx</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SX" title="ISO 3166-2:SX">ISO 3166-2:SX</a></span></td>
+          <td>The <a href="/wiki/Collectivity_of_Saint_Martin" title="Collectivity of Saint Martin">French part</a> of
+            <a
+              href="/wiki/Saint_Martin" title="Saint Martin">Saint Martin</a> island is assigned code <a
+              href="#MF"><span
+              style="font-family: monospace, monospace;">MF</span></a></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SY</span></td>
+          <td><a href="/wiki/Syria" title="Syria">Syrian Arab Republic</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.sy" title=".sy">.sy</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SY" title="ISO 3166-2:SY">ISO 3166-2:SY</a></span></td>
+          <td>ISO country name follows UN designation (common name: <i>Syria</i>)</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">SZ</span></td>
+          <td><a href="/wiki/Swaziland" title="Swaziland">Swaziland</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.sz" title=".sz">.sz</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:SZ" title="ISO 3166-2:SZ">ISO 3166-2:SZ</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TC</span></td>
+          <td><a href="/wiki/Turks_and_Caicos_Islands" title="Turks and Caicos Islands">Turks and Caicos Islands</a>
+          </td>
+          <td>1974</td>
+          <td><a href="/wiki/.tc" title=".tc">.tc</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TC" title="ISO 3166-2:TC">ISO 3166-2:TC</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TD</span></td>
+          <td><a href="/wiki/Chad" title="Chad">Chad</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.td" title=".td">.td</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TD" title="ISO 3166-2:TD">ISO 3166-2:TD</a></span></td>
+          <td>Code taken from name in <a href="/wiki/French_language" title="French language">French</a>: <i><span
+            lang="fr"
+            xml:lang="fr">Tchad</span></i>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TF</span></td>
+          <td><a href="/wiki/French_Southern_and_Antarctic_Lands" title="French Southern and Antarctic Lands">French
+            Southern
+            Territories</a></td>
+          <td>1979</td>
+          <td><a href="/wiki/.tf" title=".tf">.tf</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TF" title="ISO 3166-2:TF">ISO 3166-2:TF</a></span></td>
+          <td>Covers the French Southern and Antarctic Lands except <a href="/wiki/Ad%C3%A9lie_Land"
+                                                                       title="Adélie Land">Adélie
+            Land</a><br>
+            Code taken from name in <a href="/wiki/French_language" title="French language">French</a>: <i><span
+              lang="fr"
+              xml:lang="fr">Terres australes françaises</span></i>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TG</span></td>
+          <td><a href="/wiki/Togo" title="Togo">Togo</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.tg" title=".tg">.tg</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TG" title="ISO 3166-2:TG">ISO 3166-2:TG</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TH</span></td>
+          <td><a href="/wiki/Thailand" title="Thailand">Thailand</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.th" title=".th">.th</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TH" title="ISO 3166-2:TH">ISO 3166-2:TH</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TJ</span></td>
+          <td><a href="/wiki/Tajikistan" title="Tajikistan">Tajikistan</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.tj" title=".tj">.tj</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TJ" title="ISO 3166-2:TJ">ISO 3166-2:TJ</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TK</span></td>
+          <td><a href="/wiki/Tokelau" title="Tokelau">Tokelau</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.tk" title=".tk">.tk</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TK" title="ISO 3166-2:TK">ISO 3166-2:TK</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TL</span></td>
+          <td><a href="/wiki/East_Timor" title="East Timor">Timor-Leste</a></td>
+          <td>2002</td>
+          <td><a href="/wiki/.tl" title=".tl">.tl</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TL" title="ISO 3166-2:TL">ISO 3166-2:TL</a></span></td>
+          <td>Name changed from <i>East Timor</i> (<span style="font-family: monospace, monospace;">TP</span>)</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TM</span></td>
+          <td><a href="/wiki/Turkmenistan" title="Turkmenistan">Turkmenistan</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.tm" title=".tm">.tm</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TM" title="ISO 3166-2:TM">ISO 3166-2:TM</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TN</span></td>
+          <td><a href="/wiki/Tunisia" title="Tunisia">Tunisia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.tn" title=".tn">.tn</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TN" title="ISO 3166-2:TN">ISO 3166-2:TN</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TO</span></td>
+          <td><a href="/wiki/Tonga" title="Tonga">Tonga</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.to" title=".to">.to</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TO" title="ISO 3166-2:TO">ISO 3166-2:TO</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TR</span></td>
+          <td><a href="/wiki/Turkey" title="Turkey">Turkey</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.tr" title=".tr">.tr</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TR" title="ISO 3166-2:TR">ISO 3166-2:TR</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TT</span></td>
+          <td><a href="/wiki/Trinidad_and_Tobago" title="Trinidad and Tobago">Trinidad and Tobago</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.tt" title=".tt">.tt</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TT" title="ISO 3166-2:TT">ISO 3166-2:TT</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TV</span></td>
+          <td><a href="/wiki/Tuvalu" title="Tuvalu">Tuvalu</a></td>
+          <td>1979</td>
+          <td><a href="/wiki/.tv" title=".tv">.tv</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TV" title="ISO 3166-2:TV">ISO 3166-2:TV</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TW</span></td>
+          <td><a href="/wiki/Taiwan" title="Taiwan">Taiwan, Province of China</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.tw" title=".tw">.tw</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TW" title="ISO 3166-2:TW">ISO 3166-2:TW</a></span></td>
+          <td>Covers the current jurisdiction of the <a href="/wiki/Republic_of_China" title="Republic of China"
+                                                        class="mw-redirect">Republic of China</a> except <a
+            href="/wiki/Kinmen" title="Kinmen">Kinmen</a> and <a href="/wiki/Matsu_Islands"
+                                                                 title="Matsu Islands">Lienchiang</a><br>
+            ISO country name follows UN designation (due to <a href="/wiki/Political_status_of_Taiwan"
+                                                               title="Political status of Taiwan">political status of
+              Taiwan</a> within the UN)<sup id="cite_ref-faqs_specific_17-1" class="reference"><a
+              href="#cite_note-faqs_specific-17"><span>[</span>17<span>]</span></a></sup></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">TZ</span></td>
+          <td><a href="/wiki/Tanzania" title="Tanzania">Tanzania, United Republic of</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.tz" title=".tz">.tz</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:TZ" title="ISO 3166-2:TZ">ISO 3166-2:TZ</a></span></td>
+          <td>ISO country name follows UN designation (common name: <i>Tanzania</i>)</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">UA</span></td>
+          <td><a href="/wiki/Ukraine" title="Ukraine">Ukraine</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ua" title=".ua">.ua</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:UA" title="ISO 3166-2:UA">ISO 3166-2:UA</a></span></td>
+          <td>Previous ISO country name: <i><a href="/wiki/Ukrainian_Soviet_Socialist_Republic"
+                                               title="Ukrainian Soviet Socialist Republic">Ukrainian SSR</a></i><br>
+            Code assigned as the country was already a UN member since 1945<sup id="cite_ref-bulletin_16-1"
+                                                                                class="reference"><a
+              href="#cite_note-bulletin-16"><span>[</span>16<span>]</span></a></sup></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">UG</span></td>
+          <td><a href="/wiki/Uganda" title="Uganda">Uganda</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ug" title=".ug">.ug</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:UG" title="ISO 3166-2:UG">ISO 3166-2:UG</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">UM</span></td>
+          <td><a href="/wiki/United_States_Minor_Outlying_Islands" title="United States Minor Outlying Islands">United
+            States
+            Minor Outlying Islands</a></td>
+          <td>1986</td>
+          <td><a href="/wiki/.um" title=".um">.um</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:UM" title="ISO 3166-2:UM">ISO 3166-2:UM</a></span></td>
+          <td>Consists of nine minor insular areas of the United States: <a href="/wiki/Baker_Island"
+                                                                            title="Baker Island">Baker
+            Island</a>, <a href="/wiki/Howland_Island" title="Howland Island">Howland Island</a>, <a
+            href="/wiki/Jarvis_Island" title="Jarvis Island">Jarvis Island</a>, <a href="/wiki/Johnston_Atoll"
+                                                                                   title="Johnston Atoll">Johnston
+            Atoll</a>,
+            <a href="/wiki/Kingman_Reef" title="Kingman Reef">Kingman Reef</a>, <a href="/wiki/Midway_Atoll"
+                                                                                   title="Midway Atoll">Midway
+              Islands</a>,
+            <a
+              href="/wiki/Navassa_Island" title="Navassa Island">Navassa Island</a>, <a href="/wiki/Palmyra_Atoll"
+                                                                                        title="Palmyra Atoll">Palmyra
+              Atoll</a>, and <a href="/wiki/Wake_Island" title="Wake Island">Wake Island</a></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">US</span></td>
+          <td><a href="/wiki/United_States" title="United States">United States of America</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.us" title=".us">.us</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:US" title="ISO 3166-2:US">ISO 3166-2:US</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">UY</span></td>
+          <td><a href="/wiki/Uruguay" title="Uruguay">Uruguay</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.uy" title=".uy">.uy</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:UY" title="ISO 3166-2:UY">ISO 3166-2:UY</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">UZ</span></td>
+          <td><a href="/wiki/Uzbekistan" title="Uzbekistan">Uzbekistan</a></td>
+          <td>1992</td>
+          <td><a href="/wiki/.uz" title=".uz">.uz</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:UZ" title="ISO 3166-2:UZ">ISO 3166-2:UZ</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">VA</span></td>
+          <td><a href="/wiki/Vatican_City" title="Vatican City">Holy See</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.va" title=".va">.va</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:VA" title="ISO 3166-2:VA">ISO 3166-2:VA</a></span></td>
+          <td>Covers Vatican City, territory of the <a href="/wiki/Holy_See" title="Holy See">Holy See</a><br>
+            Previous ISO country name: <i>Vatican City State (Holy See)</i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">VC</span></td>
+          <td><a href="/wiki/Saint_Vincent_and_the_Grenadines" title="Saint Vincent and the Grenadines">Saint Vincent
+            and
+            the
+            Grenadines</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.vc" title=".vc">.vc</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:VC" title="ISO 3166-2:VC">ISO 3166-2:VC</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">VE</span></td>
+          <td><a href="/wiki/Venezuela" title="Venezuela">Venezuela, Bolivarian Republic of</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ve" title=".ve">.ve</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:VE" title="ISO 3166-2:VE">ISO 3166-2:VE</a></span></td>
+          <td>ISO country name follows UN designation (common name and previous ISO country name: <i>Venezuela</i>)</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">VG</span></td>
+          <td><a href="/wiki/British_Virgin_Islands" title="British Virgin Islands">Virgin Islands, British</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.vg" title=".vg">.vg</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:VG" title="ISO 3166-2:VG">ISO 3166-2:VG</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">VI</span></td>
+          <td><a href="/wiki/United_States_Virgin_Islands" title="United States Virgin Islands">Virgin Islands, U.S.</a>
+          </td>
+          <td>1974</td>
+          <td><a href="/wiki/.vi" title=".vi">.vi</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:VI" title="ISO 3166-2:VI">ISO 3166-2:VI</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">VN</span></td>
+          <td><a href="/wiki/Vietnam" title="Vietnam">Viet Nam</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.vn" title=".vn">.vn</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:VN" title="ISO 3166-2:VN">ISO 3166-2:VN</a></span></td>
+          <td>ISO country name follows UN designation (common name: <i>Vietnam</i>)</td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">VU</span></td>
+          <td><a href="/wiki/Vanuatu" title="Vanuatu">Vanuatu</a></td>
+          <td>1980</td>
+          <td><a href="/wiki/.vu" title=".vu">.vu</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:VU" title="ISO 3166-2:VU">ISO 3166-2:VU</a></span></td>
+          <td>Name changed from <i><a href="/wiki/New_Hebrides" title="New Hebrides">New Hebrides</a></i> (<span
+            style="font-family: monospace, monospace;">NH</span>)
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">WF</span></td>
+          <td><a href="/wiki/Wallis_and_Futuna" title="Wallis and Futuna">Wallis and Futuna</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.wf" title=".wf">.wf</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:WF" title="ISO 3166-2:WF">ISO 3166-2:WF</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">WS</span></td>
+          <td><a href="/wiki/Samoa" title="Samoa">Samoa</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ws" title=".ws">.ws</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:WS" title="ISO 3166-2:WS">ISO 3166-2:WS</a></span></td>
+          <td>Code taken from former name: <i>Western Samoa</i></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">YE</span></td>
+          <td><a href="/wiki/Yemen" title="Yemen">Yemen</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.ye" title=".ye">.ye</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:YE" title="ISO 3166-2:YE">ISO 3166-2:YE</a></span></td>
+          <td>Previous ISO country name: <i>Yemen, Republic of</i><br>
+            Code used for <a href="/wiki/North_Yemen" title="North Yemen">North Yemen</a> before 1990
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">YT</span></td>
+          <td><a href="/wiki/Mayotte" title="Mayotte">Mayotte</a></td>
+          <td>1993</td>
+          <td><a href="/wiki/.yt" title=".yt">.yt</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:YT" title="ISO 3166-2:YT">ISO 3166-2:YT</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">ZA</span></td>
+          <td><a href="/wiki/South_Africa" title="South Africa">South Africa</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.za" title=".za">.za</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:ZA" title="ISO 3166-2:ZA">ISO 3166-2:ZA</a></span></td>
+          <td>Code taken from name in <a href="/wiki/Dutch_language" title="Dutch language">Dutch</a>: <i><span
+            lang="nl"
+            xml:lang="nl">Zuid-Afrika</span></i>
+          </td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">ZM</span></td>
+          <td><a href="/wiki/Zambia" title="Zambia">Zambia</a></td>
+          <td>1974</td>
+          <td><a href="/wiki/.zm" title=".zm">.zm</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:ZM" title="ISO 3166-2:ZM">ISO 3166-2:ZM</a></span></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td ><span style="font-family: monospace, monospace;">ZW</span></td>
+          <td><a href="/wiki/Zimbabwe" title="Zimbabwe">Zimbabwe</a></td>
+          <td>1980</td>
+          <td><a href="/wiki/.zw" title=".zw">.zw</a></td>
+          <td><span class="nowrap"><a href="/wiki/ISO_3166-2:ZW" title="ISO 3166-2:ZW">ISO 3166-2:ZW</a></span></td>
+          <td>Name changed from <i><a href="/wiki/Rhodesia" title="Rhodesia">Southern Rhodesia</a></i> (<span
+            style="font-family: monospace, monospace;">RH</span>)
+          </td>
+        </tr>
+        </tbody>
+        <tfoot></tfoot>
+      </table>
+    </div>
+  </div>
+</div>
+
 <script src="lrStickyHeader.js"></script>
 <script>
   var tables = document.getElementsByTagName('table');
   lrStickyHeader(tables[0]);
   lrStickyHeader(tables[1]);
+  lrStickyHeader(tables[2], {parent: document.getElementById('scrollPanel')});
 </script>
 </body>
 </html>

--- a/lrStickyHeader.js
+++ b/lrStickyHeader.js
@@ -46,15 +46,15 @@
     eventListener: function eventListener () {
       var offsetTop = getOffset(this.thead, 'offsetTop') - Number(this.headerHeight);
       var offsetLeft = getOffset(this.thead, 'offsetLeft');
-      var parentOffsetTop = getOffset(this.parent, 'offsetTop');
-      var parentScrollTop = parentOffsetTop + this.parent.scrollTop;
+      var parentOffsetTop = this.parentIsWindow ? 0 : getOffset(this.parent, 'offsetTop');
+      var parentScrollTop = this.parentIsWindow ? parent.scrollY : parentOffsetTop + this.parent.scrollTop;
       var classes = this.thead.className.split(' ');
 
       if (this.stick !== true && (offsetTop - parentScrollTop < 0) &&
           (offsetTop + this.tbody.offsetHeight - parentScrollTop > 0)) {
         this.stick = true;
         this.treshold = offsetTop;
-        this.windowScrollY = window.scrollY;
+        this.windowScrollY = this.parentIsWindow ? 0 : window.scrollY;
         this.setWidth();
         this.thead.style.left = offsetLeft + 'px';
         this.thead.style.top = Number(this.headerHeight + parentOffsetTop - this.windowScrollY) + 'px';
@@ -66,7 +66,7 @@
         }.bind(this), 0);
       }
 
-      if (this.stick === true && this.windowScrollY !== window.scrollY) {
+      if (this.stick === true && !this.parentIsWindow && this.windowScrollY !== window.scrollY) {
         this.windowScrollY = window.scrollY;
         this.thead.style.top = Number(this.headerHeight + parentOffsetTop - this.windowScrollY) + 'px';
       }
@@ -120,6 +120,7 @@
           return parent;
         }
       },
+      parentIsWindow: {value: parent === window},
       headerHeight: {
         get: function () {
           return headerHeight;

--- a/lrStickyHeader.js
+++ b/lrStickyHeader.js
@@ -47,11 +47,11 @@
       var offsetTop = getOffset(this.thead, 'offsetTop') - Number(this.headerHeight);
       var offsetLeft = getOffset(this.thead, 'offsetLeft');
       var parentOffsetTop = this.parentIsWindow ? 0 : getOffset(this.parent, 'offsetTop');
-      var parentScrollTop = this.parentIsWindow ? parent.scrollY : parentOffsetTop + this.parent.scrollTop;
+      var parentScrollTop = this.parentIsWindow ? parent.scrollY : this.parent.scrollTop;
       var classes = this.thead.className.split(' ');
 
-      if (this.stick !== true && (offsetTop - parentScrollTop < 0) &&
-          (offsetTop + this.tbody.offsetHeight - parentScrollTop > 0)) {
+      if (this.stick !== true && (offsetTop - (parentOffsetTop + parentScrollTop) < 0) &&
+          (offsetTop + this.tbody.offsetHeight - (parentOffsetTop + parentScrollTop) > 0)) {
         this.stick = true;
         this.treshold = offsetTop;
         this.windowScrollY = this.parentIsWindow ? 0 : window.scrollY;
@@ -72,8 +72,8 @@
       }
 
       if (this.stick === true && (
-                  (this.treshold - parentScrollTop > 0) ||
-                  (this.treshold + this.element.offsetHeight - parentScrollTop < 0))) {
+                 (this.parentIsWindow && (this.treshold - parentScrollTop > 0)) ||
+                 (parentScrollTop <= 0))) {
         this.stick = false;
         this.thead.style.position = 'initial';
         classes.splice(classes.indexOf('lr-sticky-header'), 1);


### PR DESCRIPTION
Enable the sticky header in fixed height parent (with `overflow: auto`)

This fixes #11, #13 and replaces #12.
